### PR TITLE
Fix OPSC4 codelist import and add exampls

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -1,11 +1,10 @@
 #' @importFrom tibble tibble
 NULL
 
-#' SNOMED Code Usage in Primary Care in England
+#' Yearly SNOMED-CT Code Usage in Primary Care in England
 #'
-#' Yearly summary of code usage from 1st August 2011 to 31st July 2023.
+#' Yearly summary of SNOMED-CT code usage from 1st August 2011 to 31st July 2023.
 #' The variables in this dataset include:
-#'
 #' @format A data frame with 1,366,513 rows and 6 columns:
 #' \describe{
 #'   \item{start_date}{Start date of code usage count}
@@ -19,15 +18,24 @@ NULL
 #'   \item{description}{Description of SNOMED Concept ID}
 #' }
 #' @source <https://digital.nhs.uk/data-and-information/publications/statistical/mi-snomed-code-usage-in-primary-care>
+#' @examples
+#' # Filter for code usage records from 2022-08-01 onwards
+#' snomed_usage |>
+#'   dplyr::filter(start_date >= "2022-08-1")
+#' 
+#' # Filter for code usage records from 2022-08-01 onwards
+#' # where the description contains the word "anxiety"
+#' snomed_usage |>
+#'   dplyr::filter(start_date >= "2022-08-1") |>
+#'   dplyr::filter(grepl("anxiety", description, ignore.case = TRUE))
 "snomed_usage"
 
-#' ICD-10 Code Usage from Hospital Admitted Patient Care Activity in England
+#' Yearly ICD-10 Code Usage from Hospital Admitted Patient Care Activity in England
 #'
 #' Yearly summary of ICD-10 code usage from 1st April 2013 to 31st March 2024.
 #' All diagnosis codes are summarised to the 4-character level.
 #' The code usage represents the total annual count of episodes which record in any primary or secondary position.
 #' Restricted codes for which annual usage is not published, have been removed.
-#'
 #' @format A data frame with 135,951 rows and 5 columns:
 #' \describe{
 #'   \item{start_date}{Start date of code usage count}
@@ -40,13 +48,12 @@ NULL
 #' @source <https://digital.nhs.uk/data-and-information/publications/statistical/hospital-admitted-patient-care-activity>
 "icd10_usage"
 
-#' OPCS Code Usage from Hospital Admitted Patient Care Activity in England
+#' Yearly OPCS Code Usage from Hospital Admitted Patient Care Activity in England
 #'
 #' Yearly summary of OPCS code usage from 1st April 2013 to 31st March 2024.
 #' All procedure codes are summarised to the 4-character level.
 #' The code usage represents total annual count of each procedure, recorded across the primary and the secondary procedure positions.
 #' Restricted codes for which annual usage is not published, have been removed.
-#'
 #' @format A data frame with 107,376 rows and 5 columns:
 #' \describe{
 #'   \item{start_date}{Start date of code usage count}

--- a/R/opencodelists.R
+++ b/R/opencodelists.R
@@ -36,14 +36,25 @@ get_codelist_organisation <- function(codelist_slug) {
   }
 }
 
-#' Get codelist from OpenCodelists
+#' Get codelist from [OpenCodelists](https://www.opencodelists.org)
 #'
 #' @param codelist_slug String, specifying the slug of the codelist.
 #' The naming convention of the codelist slug follows this structure: a `<codelist-id>` is followed by / and a `<version-id>`.
 #' Note that the version ID is a sequence of 8 characters.
 #' Some codelists may also have a version tag in the form of a date (YYYY-MM-DD) or a version number (e.g., v1.2) that can be used in place of the version ID.
 #' @export
-#'
+#' @examples
+#' # Get the 'cpeptide_cod' codelist from OpenCodelists.org
+#' cpeptide_cod <- get_codelist("nhsd-primary-care-domain-refsets/cpeptide_cod/20200812/")
+#' 
+#' # Return all codes
+#' cpeptide_cod$code
+#' 
+#' # Return 'coding_system' of codelist
+#' cpeptide_cod@coding_system
+#' 
+#' # Return 'full_slug' of codelist
+#' cpeptide_cod@full_slug
 get_codelist <- function(codelist_slug) {
   codelist_slug <- sub("/$", "", codelist_slug)
   url_api_base <- "https://www.opencodelists.org/api/v1/codelist/"

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -1,4 +1,4 @@
-#' Interactive tool to explore clinical code usage
+#' Run [Code Usage Explorer](https://milanwiedemann.shinyapps.io/codeusage/) Shiny App
 #'
 #' @export
 run_app <- function() {

--- a/R/server.R
+++ b/R/server.R
@@ -34,7 +34,7 @@ app_server <- function(input, output, session) {
     } else if (input$dataset == "icd10") {
       codeusage::icd10_usage |>
         select(start_date, end_date, code = icd10_code, description, usage)
-    } else if (input$dataset == "opcs") {
+    } else if (input$dataset == "opcs4") {
       codeusage::opcs_usage |>
         select(start_date, end_date, code = opcs_code, description, usage)
     }

--- a/R/ui.R
+++ b/R/ui.R
@@ -16,12 +16,26 @@ app_ui <- function(request) {
     title = "Code Usage Explorer",
     sidebar = sidebar(
       card(
-        card_header("Select dataset"),
+        card_header(
+          tooltip(
+            span(
+              "Select dataset",
+              bs_icon("info-circle")
+            ),
+            "SNOMED CT (Systematized Nomenclature of Medicine Clinical Terms); ICD (International Classification of Diseases); OPCS Classification of Interventions and Procedures",
+            options = list(
+              customClass = "left-align-tooltip"
+            )
+          )
+        ),
         radioButtons("dataset", NULL,
           choices = c(
+            # Systematized Nomenclature of Medicine Clinical Terms (SNOMED CT)
             "SNOMED-CT" = "snomedct",
+            # International Classification of Diseases (ICD)
             "ICD-10" = "icd10",
-            "OPCS" = "opcs"
+            # OPCS Classification of Interventions and Procedures (OPCS)
+            "OPCS" = "opcs4"
           )
         )
       ),
@@ -50,7 +64,7 @@ app_ui <- function(request) {
               "Description",
               bs_icon("info-circle")
             ),
-            "Enter search term(s). Multiple terms can be combined by using '|' e.g., 'anxiety|depression'",
+            "Enter search term(s). Multiple terms can be combined by using '|'.",
             options = list(
               customClass = "left-align-tooltip"
             )

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,15 @@ url: https://ebmdatalab.github.io/codeusage/
 template:
   bootstrap: 5
 
+reference:
+- title: Datasets
+  contents:
+  - snomed_usage
+  - icd10_usage
+  - opcs_usage
+- title: Codelists
+  contents:
+  - get_codelist
+- title: Shiny App
+  contents:
+  - run_app

--- a/man/get_codelist.Rd
+++ b/man/get_codelist.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/opencodelists.R
 \name{get_codelist}
 \alias{get_codelist}
-\title{Get codelist from OpenCodelists}
+\title{Get codelist from \href{https://www.opencodelists.org}{OpenCodelists}}
 \usage{
 get_codelist(codelist_slug)
 }
@@ -13,5 +13,18 @@ Note that the version ID is a sequence of 8 characters.
 Some codelists may also have a version tag in the form of a date (YYYY-MM-DD) or a version number (e.g., v1.2) that can be used in place of the version ID.}
 }
 \description{
-Get codelist from OpenCodelists
+Get codelist from \href{https://www.opencodelists.org}{OpenCodelists}
+}
+\examples{
+# Get the 'cpeptide_cod' codelist from OpenCodelists.org
+cpeptide_cod <- get_codelist("nhsd-primary-care-domain-refsets/cpeptide_cod/20200812/")
+
+# Return all codes
+cpeptide_cod$code
+
+# Return 'coding_system' of codelist
+cpeptide_cod@coding_system
+
+# Return 'full_slug' of codelist
+cpeptide_cod@full_slug
 }

--- a/man/icd10_usage.Rd
+++ b/man/icd10_usage.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{icd10_usage}
 \alias{icd10_usage}
-\title{ICD-10 Code Usage from Hospital Admitted Patient Care Activity in England}
+\title{Yearly ICD-10 Code Usage from Hospital Admitted Patient Care Activity in England}
 \format{
 A data frame with 135,951 rows and 5 columns:
 \describe{

--- a/man/opcs_usage.Rd
+++ b/man/opcs_usage.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{opcs_usage}
 \alias{opcs_usage}
-\title{OPCS Code Usage from Hospital Admitted Patient Care Activity in England}
+\title{Yearly OPCS Code Usage from Hospital Admitted Patient Care Activity in England}
 \format{
 A data frame with 107,376 rows and 5 columns:
 \describe{

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -2,10 +2,10 @@
 % Please edit documentation in R/run_app.R
 \name{run_app}
 \alias{run_app}
-\title{Interactive tool to explore clinical code usage}
+\title{Run \href{https://milanwiedemann.shinyapps.io/codeusage/}{Code Usage Explorer} Shiny App}
 \usage{
 run_app()
 }
 \description{
-Interactive tool to explore clinical code usage
+Run \href{https://milanwiedemann.shinyapps.io/codeusage/}{Code Usage Explorer} Shiny App
 }

--- a/man/snomed_usage.Rd
+++ b/man/snomed_usage.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{snomed_usage}
 \alias{snomed_usage}
-\title{SNOMED Code Usage in Primary Care in England}
+\title{Yearly SNOMED-CT Code Usage in Primary Care in England}
 \format{
 A data frame with 1,366,513 rows and 6 columns:
 \describe{
@@ -25,7 +25,18 @@ Counts of 5 or below are displayed as 5.}
 snomed_usage
 }
 \description{
-Yearly summary of code usage from 1st August 2011 to 31st July 2023.
+Yearly summary of SNOMED-CT code usage from 1st August 2011 to 31st July 2023.
 The variables in this dataset include:
+}
+\examples{
+# Filter for code usage records from 2022-08-01 onwards
+snomed_usage |>
+  dplyr::filter(start_date >= "2022-08-1")
+
+# Filter for code usage records from 2022-08-01 onwards
+# where the description contains the word "anxiety"
+snomed_usage |>
+  dplyr::filter(start_date >= "2022-08-1") |>
+  dplyr::filter(grepl("anxiety", description, ignore.case = TRUE))
 }
 \keyword{datasets}


### PR DESCRIPTION
We should add similar examples for the other datasets as well. The examples get rendered automatically and look nice when calling the `help()` file or on the documentation of the website when using `pkgdown::build_site()`.