### PR TITLE
Update link to hosted Shiny app

### DIFF
--- a/vignettes/app.Rmd
+++ b/vignettes/app.Rmd
@@ -23,6 +23,6 @@ vignette: >
 </style>
 
 <div class="shiny-app-frame"> 
-<iframe src="https://milanwiedemann.shinyapps.io/opencodecounts-1/">
+<iframe src="https://milanwiedemann.shinyapps.io/opencodecounts/">
 </iframe>
 </div>


### PR DESCRIPTION
The new app is now online at https://milanwiedemann.shinyapps.io/opencodecounts/. This is why we were still getting errors using the app linked from https://bennettoxford.github.io/opencodecounts/ but not when launching locally.