### PR TITLE
Add preprint as citation

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,8 @@
+bibentry(
+  bibtype  = "Article",
+  title    = "OpenCodeCounts: An open-access, interactive online tool and R package for analysing clinical code usage in England",
+  author   = "Arina Anna Tamborska, Rose Higgins, Yamina Boukari, Viveck Kingsley, Lola Ojedele, Kunle Oreagba, Jon Massey, Andrea Schaffer, Amelia Green, William Hulme, Brian MacKenna, Helen J Curtis, Louis Fisher, Milan Wiedemann",
+  journal  = "medRxiv",
+  year     = "2025",
+  doi      = "10.1101/2025.10.14.25338005"
+)


### PR DESCRIPTION
Closes #90 

```R
> citation("opencodecounts")
# To cite package ‘opencodecounts’ in publications use:
# 
#   Tamborska AA, Higgins R, Boukari Y, Kingsley V, Ojedele L, Oreagba K, Massey J, Schaffer A, Green A, Hulme W, MacKenna B, Curtis HJ, Fisher L, Wiedemann M (2025). “OpenCodeCounts: An open-access, interactive online tool and R package for analysing clinical code usage in England.” _medRxiv_. doi:10.1101/2025.10.14.25338005 <https://doi.org/10.1101/2025.10.14.25338005>.
# 
# A BibTeX entry for LaTeX users is
# 
#   @Article{,
#     title = {OpenCodeCounts: An open-access, interactive online tool and R package for analysing clinical code usage in England},
#     author = {Arina Anna Tamborska and Rose Higgins and Yamina Boukari and Viveck Kingsley and Lola Ojedele and Kunle Oreagba and Jon Massey and Andrea Schaffer and Amelia Green and William Hulme and Brian MacKenna and Helen J Curtis and Louis Fisher and Milan Wiedemann},
#     journal = {medRxiv},
#     year = {2025},
#     doi = {10.1101/2025.10.14.25338005},
#   }
```